### PR TITLE
Update

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,16 @@
+turnkey-e107-14.0 (1) turnkey; urgency=low
+
+  * Upgraded to latest stable version of e107.
+
+  * Upstrean source component versions:
+
+    e107            1.0.2
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- OnGle <nafets.sivad@gmail.com>  Tue, 26 May 2015 00:52:45 +0000
+
 turnkey-e107-13.0 (1) turnkey; urgency=low
 
   * PHPMyAdmin:

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -5,7 +5,7 @@ dl() {
     cd $2; curl -L -f -O $PROXY $1; cd -
 }
 
-VERSION="e107%20v1.0.2/e107_1.0.2_full.tar.gz"
+VERSION="e107%20v1.0.4/e107_1.0.4_full.tar.gz"
 URL="http://sourceforge.net/projects/e107/files/e107/$VERSION"
 
 dl $URL /usr/local/src


### PR DESCRIPTION
It's worth noting that e107 v2.0 is out but only in beta and even though 1.0.4 is the newest stable it is also legacy for some reason, so it stands to reason that 2.0 full release probably isn't far away.
